### PR TITLE
Merge branch 'release/2.1.0' into develop

### DIFF
--- a/.changes/v2.1.0.md
+++ b/.changes/v2.1.0.md
@@ -1,0 +1,19 @@
+## [v2.1.0](https://github.com/ansidev/astro-basic-template/compare/v2.0.1...v2.1.0) (2023-03-01)
+
+### Bug Fixes
+
+- set dir for internal task to avoid wrong working directory
+
+- delete existing branch before initializing
+
+### Features
+
+- **cli-command:** add command `leetcode` for generating new solution post
+
+- **deploy:** update environment variable
+
+- **disqus-comment:** add Disqus comment to post page
+
+- **seo:** add canonical URL meta field
+
+Full Changelog: [v2.0.1...v2.1.0](https://github.com/ansidev/astro-basic-template/compare/v2.0.1...v2.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v2.1.0](https://github.com/ansidev/astro-basic-template/compare/v2.0.1...v2.1.0) (2023-03-01)
+
+### Bug Fixes
+
+- set dir for internal task to avoid wrong working directory
+
+- delete existing branch before initializing
+
+### Features
+
+- **cli-command:** add command `leetcode` for generating new solution post
+
+- **deploy:** update environment variable
+
+- **disqus-comment:** add Disqus comment to post page
+
+- **seo:** add canonical URL meta field
+
+Full Changelog: [v2.0.1...v2.1.0](https://github.com/ansidev/astro-basic-template/compare/v2.0.1...v2.1.0)
+
 ## [v2.0.1](https://github.com/ansidev/astro-basic-template/compare/v2.0.0...v2.0.1) (2023-02-26)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "leetcode-blog",
   "description": "Solutions for LeetCode problems - Written by ansidev",
   "type": "module",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "license": "MIT",
   "scripts": {
     "lc:new": "tsx ./src/cmd/leetcode.ts",


### PR DESCRIPTION
This PR merges the branch 'release/2.1.0' back into the branch 'develop'.

This ensures that the updates on the branch 'release/2.1.0', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
