### PR TITLE
Merge branch release/2.2.5 into develop

### DIFF
--- a/.changes/v2.2.5.md
+++ b/.changes/v2.2.5.md
@@ -1,0 +1,31 @@
+## [v2.2.5](https://github.com/ansidev/leetcode-blog/compare/v2.2.4...v2.2.5) (2023-06-13)
+
+### Bug Fixes
+
+- **github-workflow:** wrong github environment url
+
+### Code Refactoring
+
+- **github-workflow:** apply GitHub Actions from ghacts
+
+- **github-workflow:** apply GitHub Actions from ghacts/gitflow
+
+### Dependencies
+
+| Package                            | Version                   |
+| ---------------------------------- | ------------------------- |
+| `@astrojs/sitemap`                 | `^1.3.2` `->` `^1.3.3`    |
+| `astro`                            | `^2.5.6` `->` `2.6.3`     |
+| `astro-compress`                   | `^1.1.46` `->` `^1.1.47`  |
+| `@fontsource/ibm-plex-mono`        | `^5.0.2` `->` `^5.0.3`    |
+| `@iconify-json/bi`                 | `^1.1.16` `->` `^1.1.17`  |
+| `@typescript-eslint/eslint-plugin` | `^5.59.8` `->` `^5.59.11` |
+| `@typescript-eslint/parser`        | `^5.59.8` `->` `^5.59.11` |
+| `dayjs`                            | `^1.11.7` `->` `^1.11.8`  |
+| `dotenv`                           | `^16.1.1` `->` `^16.1.4`  |
+| `eslint`                           | `^8.41.0` `->` `^8.42.0`  |
+| `sass`                             | `^1.62.1` `->` `^1.63.3`  |
+| `satori`                           | `^0.9.1` `->` `^0.10.1`   |
+| `typescript`                       | `^5.0.4` `->` `^5.1.3`    |
+
+Full Changelog: [v2.2.4...v2.2.5](https://github.com/ansidev/leetcode-blog/compare/v2.2.4...v2.2.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v2.2.5](https://github.com/ansidev/leetcode-blog/compare/v2.2.4...v2.2.5) (2023-06-13)
+
+### Bug Fixes
+
+- wrong github environment url
+
+- **deps:** update dependency astro to v2.6.3
+
+- **deps:** update dependency astro to v2.6.2
+
+- **deps:** update dependency astro to v2.6.1
+
+- **deps:** update dependency astro to v2.6.0
+
+- **deps:** update dependency astro-compress to ^1.1.47
+
+- **deps:** update dependency astro to v2.5.7
+
+- **deps:** update dependency [@astrojs](https://github.com/astrojs)/sitemap to ^1.3.3
+
+### Code Refactoring
+
+- **github-workflow:** apply GitHub Actions from ghacts
+
+- **github-workflow:** apply GitHub Actions from ghacts/gitflow
+
+Full Changelog: [v2.2.4...v2.2.5](https://github.com/ansidev/leetcode-blog/compare/v2.2.4...v2.2.5)
+
 ## [v2.2.4](https://github.com/ansidev/leetcode-blog/compare/v2.2.3...v2.2.4) (2023-05-31)
 
 ### Content

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "leetcode-blog",
   "description": "Solutions for LeetCode problems - Written by ansidev",
   "type": "module",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "license": "MIT",
   "packageManager": "pnpm@8.6.2",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch `release/2.2.5` back into the branch `develop`.

This ensures that the updates on the branch `release/2.2.5`, i.e. CHANGELOG and manifest updates, are also present on the branch `develop`.