### PR TITLE
fix: migrate deprecated Astro v5 Content Layer APIs

### DIFF
--- a/src/components/post/PostList.astro
+++ b/src/components/post/PostList.astro
@@ -15,7 +15,7 @@ const { posts = [] } = Astro.props
     posts.map((p) => (
       <PostItem
         title={p.data.title}
-        href={`/${p.slug}`}
+        href={`/${p.id}`}
         difficulty={p.data.difficulty}
       />
     ))

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,8 @@
+import { glob } from 'astro/loaders';
 import { defineCollection, z } from 'astro:content'
 
 const leetcodeSolutionCollection = defineCollection({
+  loader: glob({ pattern: '**/[^_]*.md', base: './src/content/leetcode-solutions' }),
   schema: z.object({
     title: z.string(),
     keywords: z.array(z.string()),

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import { type CollectionEntry, getCollection } from 'astro:content'
+import { type CollectionEntry, getCollection, render } from 'astro:content'
 
 import Disqus from '@/components/Disqus.astro'
 import PostLayout from '@/layouts/PostLayout.astro'
@@ -9,7 +9,7 @@ export async function getStaticPaths() {
   const allPosts = await getCollection('leetcode-solutions')
   return allPosts.map((entry) => ({
     params: {
-      slug: entry.slug,
+      slug: entry.id,
     },
     props: {
       entry,
@@ -20,10 +20,10 @@ export async function getStaticPaths() {
 type Props = CollectionEntry<'leetcode-solutions'>
 
 const { entry } = Astro.props
-const { Content } = await entry.render()
+const { Content } = await render(entry)
 ---
 
-<PostLayout frontmatter={entry.data} slug={entry.slug}>
+<PostLayout frontmatter={entry.data} slug={entry.id}>
   <Content />
   {
     isPluginEnabled('disqus') && (

--- a/src/pages/images/[slug].png.ts
+++ b/src/pages/images/[slug].png.ts
@@ -2,7 +2,7 @@ import IBMPlexMonoRegular from '@fontsource/ibm-plex-mono/files/ibm-plex-mono-la
 import IBMPlexMonoBold from '@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-700-normal.woff'
 import { Resvg } from '@resvg/resvg-js'
 import type { APIContext } from 'astro'
-import { getCollection, getEntryBySlug } from 'astro:content'
+import { getCollection, getEntry } from 'astro:content'
 import satori from 'satori'
 import { html } from 'satori-html'
 
@@ -15,11 +15,11 @@ const dimensions = {
 
 const { author } = siteConfig
 
-export async function get({ site, params }: APIContext) {
+export async function GET({ site, params }: APIContext) {
   const url = new URL(site)
   const siteAddr = url.host
 
-  const post = await getEntryBySlug('leetcode-solutions', params.slug)
+  const post = await getEntry('leetcode-solutions', params.slug)
   const { title, pubDate } = post?.data || { title: '', pubDate: new Date() }
 
   const titleArr = title.split('. ')
@@ -93,10 +93,9 @@ export async function get({ site, params }: APIContext) {
     },
   }).render()
 
-  return {
-    body: image.asPng(),
-    encoding: 'binary',
-  }
+  return new Response(image.asPng(), {
+    headers: { 'Content-Type': 'image/png' },
+  })
 }
 
 export async function getStaticPaths() {
@@ -104,7 +103,7 @@ export async function getStaticPaths() {
   const paths = posts.map((post) => {
     return {
       params: {
-        slug: post.slug,
+        slug: post.id,
       },
     }
   })

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -23,7 +23,7 @@ export const GET = async ({ site }: APIContext) => {
       title: post.data.title,
       description: `LeetCode Problem #${post.data.title}`,
       pubDate: new Date(post.data.pubDate),
-      link: `/${post.slug}`,
+      link: `/${post.id}`,
     })),
     customData: '<language>en-US</language>',
   })


### PR DESCRIPTION
## Summary

- Rename `src/content/config.ts` → `src/content.config.ts` (Astro v5 convention)
- Add `glob` loader to collection definition in `content.config.ts`
- Replace `entry.slug` with `entry.id` across all pages and components (`[slug].astro`, `PostList.astro`, `rss.xml.ts`, `images/[slug].png.ts`)
- Replace `entry.render()` with `render(entry)` imported from `astro:content` in `[slug].astro`
- Replace removed `getEntryBySlug` with `getEntry` in `images/[slug].png.ts`
- Rename lowercase `get` handler to uppercase `GET` in `images/[slug].png.ts` (required by Astro v5)
- Return `new Response()` instead of legacy `{ body, encoding }` object in `images/[slug].png.ts`

## Test plan

- [x] `pnpm build` completes successfully with no errors or warnings
- [x] All post pages render correctly
- [x] OG images (`/images/*.png`) are generated correctly
- [x] RSS feed (`/rss.xml`) is generated correctly